### PR TITLE
Harden CS72 v1.7 firmware: motor current bounds, fan clamping, and StallGuard handling

### DIFF
--- a/MicroController/CS72_Firmware_V1.7/CS72_Firmware_V1.7.ino
+++ b/MicroController/CS72_Firmware_V1.7/CS72_Firmware_V1.7.ino
@@ -259,7 +259,7 @@ void setup() {
   feedmotorUART.ihold(2);
   feedmotorUART.intpol(true);
  
-  sortmotorUART.rms_current(1000);       // Set motor RMS current
+  sortmotorUART.rms_current(SORT_CURRENT);       // Set motor RMS current
   sortmotorUART.microsteps(SORT_MICROSTEPS); 
   sortmotorUART.pwm_autoscale(true);    // Needed for stealthChop
   sortmotorUART.en_spreadCycle(false);   // false = StealthChop / true = SpreadCycle
@@ -422,6 +422,9 @@ void checkSerial(){
        if(input.startsWith("feedmotorcurrent:")){
             input.replace("feedmotorcurrent:", "");
             feedCurrent = input.toInt();
+            if(feedCurrent<100){
+              feedCurrent=100;
+            }
             if(feedCurrent>1800){
               feedCurrent=1800;
             }
@@ -433,6 +436,9 @@ void checkSerial(){
       if(input.startsWith("sortmotorcurrent:")){
             input.replace("sortmotorcurrent:", "");
             sortCurrent = input.toInt();
+            if(sortCurrent<100){
+              sortCurrent=100;
+            }
             if(sortCurrent>1800){
               sortCurrent=1800;
             }
@@ -651,6 +657,12 @@ void checkSerial(){
       if (input.startsWith("fan:")) {
         input.replace("fan:", "");
         caseFanLevel = input.toInt();
+        if(caseFanLevel < 0){
+          caseFanLevel = 0;
+        }
+        if(caseFanLevel > 100){
+          caseFanLevel = 100;
+        }
         adjustFanLevel(caseFanLevel);
         Serial.print(F("ok\n"));
         resetCommand();
@@ -1184,6 +1196,7 @@ void homeSortMotor(){
 void stepFeedMotor(){
       if (checkStallGuardWhileMoving(FEED_DIAG_PIN, feedStepCounter)) {
         triggerFeedStall(F("error:feed stallguard (homing)"));
+        return;
       }
     digitalWrite(FEED_ENABLE, LOW);
     digitalWrite(FEED_STEPPIN, HIGH);
@@ -1268,10 +1281,12 @@ void adjustCameraLED(int level)
 
 void adjustFanLevel(int level)
 {
+  level = level < 0 ? 0 : level;
+  level = level > 100 ? 100 : level;
   fanPercentConversion = level * 2.55;
   level = fanPercentConversion;
   analogWrite(CASEFAN_PWM, level);
-  //caseFanLevel = level;
+  caseFanLevel = (int)(fanPercentConversion / 2.55);
  }
 
 
@@ -1311,7 +1326,7 @@ bool checkStallGuardWhileMoving(
     return false;
   }
   // With INPUT_PULLUP, DIAG (open-drain) typically asserts LOW
-  return digitalRead(diagPin) == HIGH;
+  return diagActive(diagPin);
 }
 
 
@@ -1353,4 +1368,3 @@ void triggerSortStall(const __FlashStringHelper* msg) {
 
   Serial.println(msg);
 }
-


### PR DESCRIPTION
### Motivation
- Reduce runtime failures and protect motors and electronics by enforcing sane command bounds and unifying StallGuard behavior. 
- Prevent the feed motor from taking an extra step after a StallGuard trip and ensure fan PWM always receives a valid percentage.

### Description
- Initialize the sorter driver with `SORT_CURRENT` instead of a hardcoded value to match configured startup current. 
- Add a lower-bound clamp of `100` mA for `feedmotorcurrent:` and `sortmotorcurrent:` serial commands while preserving the existing `1800` mA upper cap. 
- Clamp `fan:` serial input to the range `0..100` and add defensive clamping inside `adjustFanLevel()` while keeping `caseFanLevel` synchronized to the effective applied percentage. 
- Stop stepping the feed motor immediately when StallGuard trips by returning after `triggerFeedStall(...)`, and unify StallGuard active-state checks by using `diagActive(diagPin)` in `checkStallGuardWhileMoving()`.

### Testing
- Verified the presence of the intended initialization change and guards by searching for the patterns with `rg -n "rms_current\(SORT_CURRENT\)|feedCurrent<100|sortCurrent<100|caseFanLevel < 0|caseFanLevel > 100|return diagActive\(diagPin\);|void adjustFanLevel\(int level\)" MicroController/CS72_Firmware_V1.7/CS72_Firmware_V1.7.ino`, which succeeded. 
- Inspected the modified source regions with `nl -ba MicroController/CS72_Firmware_V1.7/CS72_Firmware_V1.7.ino | sed -n '<ranges>p'` to confirm the edits were applied, which succeeded. 
- Attempted to run a build tool but `arduino-cli` is not available in this environment, so a compile/upload validation could not be run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e0fceaf588322a976bf6c1f3be128)